### PR TITLE
feat: add calico CNI patch

### DIFF
--- a/aws/README.md
+++ b/aws/README.md
@@ -18,6 +18,8 @@ Unless you have Direct Connect or some VPN to your AWS environment, VMs on this 
 
 For the multi-AZ setup, it is assumed that the user has pre-created both private and public subnets for use, as well as a loadbalancer that will be used to target the Talos control plane nodes at port 50000.
 
+Calico is the only supported CNI right now. The AWS Cluster API provider sets up Calico rules by default in its created security groups. Other CNIs can likely be used, but it will take some extra work on setting up the groups manually and specifying them as extra groups in the cluster manifests.
+
 ## Preparation
 
 ### Cloud

--- a/aws/autoscaling-workers/autoscaling-workers.env
+++ b/aws/autoscaling-workers/autoscaling-workers.env
@@ -4,6 +4,7 @@ export REGION=us-east-1
 export SSH_KEY=talos-ssh
 export VPC_ID=vpc-xxyyyzz
 export SUBNET=subnet-xxyyzz
+export CALICO_VERSION=v3.18
 export K8S_VERSION=1.21.0
 export TALOS_VERSION=v0.10
 export CLOUD_PROVIDER_VERSION=v1.20.0-alpha.0

--- a/aws/autoscaling-workers/autoscaling-workers.yaml
+++ b/aws/autoscaling-workers/autoscaling-workers.yaml
@@ -71,6 +71,12 @@ spec:
       talosVersion: ${TALOS_VERSION}
       configPatches:
         - op: add
+          path: /cluster/network/cni
+          value:
+            name: custom
+            urls:
+              - https://docs.projectcalico.org/${CALICO_VERSION}/manifests/calico.yaml
+        - op: add
           path: /machine/kubelet/registerWithFQDN
           value: true
         - op: add
@@ -84,6 +90,12 @@ spec:
       generateType: controlplane
       talosVersion: ${TALOS_VERSION}
       configPatches:
+        - op: add
+          path: /cluster/network/cni
+          value:
+            name: custom
+            urls:
+              - https://docs.projectcalico.org/${CALICO_VERSION}/manifests/calico.yaml
         - op: add
           path: /machine/kubelet/registerWithFQDN
           value: true

--- a/aws/multi-az/multi-az.env
+++ b/aws/multi-az/multi-az.env
@@ -13,6 +13,7 @@ export REGION=us-east-1
 export SSH_KEY=talos-ssh
 export VPC_ID=vpc-xxyyyzz
 export SUBNET=subnet-xxyyzz
+export CALICO_VERSION=v3.18
 export K8S_VERSION=1.21.0
 export TALOS_VERSION=v0.10
 export CLOUD_PROVIDER_VERSION=v1.20.0-alpha.0

--- a/aws/multi-az/multi-az.yaml
+++ b/aws/multi-az/multi-az.yaml
@@ -67,6 +67,12 @@ spec:
       talosVersion: ${TALOS_VERSION}
       configPatches:
         - op: add
+          path: /cluster/network/cni
+          value:
+            name: custom
+            urls:
+              - https://docs.projectcalico.org/${CALICO_VERSION}/manifests/calico.yaml
+        - op: add
           path: /machine/kubelet/registerWithFQDN
           value: true
         - op: add
@@ -84,6 +90,12 @@ spec:
       generateType: controlplane
       talosVersion: ${TALOS_VERSION}
       configPatches:
+        - op: add
+          path: /cluster/network/cni
+          value:
+            name: custom
+            urls:
+              - https://docs.projectcalico.org/${CALICO_VERSION}/manifests/calico.yaml
         - op: add
           path: /machine/kubelet/registerWithFQDN
           value: true

--- a/aws/standard/standard.env
+++ b/aws/standard/standard.env
@@ -4,6 +4,7 @@ export REGION=us-east-1
 export SSH_KEY=talos-ssh
 export VPC_ID=vpc-xxyyyzz
 export SUBNET=subnet-xxyyzz
+export CALICO_VERSION=v3.18
 export K8S_VERSION=1.21.0
 export TALOS_VERSION=v0.10
 export CLOUD_PROVIDER_VERSION=v1.20.0-alpha.0

--- a/aws/standard/standard.yaml
+++ b/aws/standard/standard.yaml
@@ -71,6 +71,12 @@ spec:
       talosVersion: ${TALOS_VERSION}
       configPatches:
         - op: add
+          path: /cluster/network/cni
+          value:
+            name: custom
+            urls:
+              - https://docs.projectcalico.org/${CALICO_VERSION}/manifests/calico.yaml
+        - op: add
           path: /machine/kubelet/registerWithFQDN
           value: true
         - op: add
@@ -84,6 +90,12 @@ spec:
       generateType: controlplane
       talosVersion: ${TALOS_VERSION}
       configPatches:
+        - op: add
+          path: /cluster/network/cni
+          value:
+            name: custom
+            urls:
+              - https://docs.projectcalico.org/${CALICO_VERSION}/manifests/calico.yaml
         - op: add
           path: /machine/kubelet/registerWithFQDN
           value: true


### PR DESCRIPTION
This PR adds calico as the default CNI for these templates. This is
needed because the AWS cluster API provider expects calico to be used.
We will eventually make this tweakable, but that's for another time.

Signed-off-by: Spencer Smith <spencer.smith@talos-systems.com>
