### PR TITLE
feat: update templates to use clusterctl var names

### DIFF
--- a/aws/autoscaling-workers/autoscaling-workers.env
+++ b/aws/autoscaling-workers/autoscaling-workers.env
@@ -1,28 +1,28 @@
 ## Cluster-wide vars
 export CLUSTER_NAME=talos-aws-test
-export REGION=us-east-1
-export SSH_KEY=talos-ssh
-export VPC_ID=vpc-xxyyyzz
-export SUBNET=subnet-xxyyzz
+export AWS_REGION=us-east-1
+export AWS_SSH_KEY_NAME=talos-ssh
+export AWS_VPC_ID=vpc-xxyyyzz
+export AWS_SUBNET=subnet-xxyyzz
 export CALICO_VERSION=v3.18
-export K8S_VERSION=1.21.0
+export KUBERNETES_VERSION=1.21.0
 export TALOS_VERSION=v0.10
-export CLOUD_PROVIDER_VERSION=v1.20.0-alpha.0
+export AWS_CLOUD_PROVIDER_VERSION=v1.20.0-alpha.0
 
 ## Control plane vars
-export CP_COUNT=3
-export CP_INSTANCE_TYPE=t3.large
-export CP_VOL_SIZE=50
-export CP_AMI_ID=ami-xxyyzz
-export CP_ADDL_SEC_GROUPS='[{id: sg-xxyyzz}]'
-export CP_IAM_PROFILE=CAPI_AWS_ControlPlane
+export CONTROL_PLANE_MACHINE_COUNT=3
+export AWS_CONTROL_PLANE_MACHINE_TYPE=t3.large
+export AWS_CONTROL_PLANE_VOL_SIZE=50
+export AWS_CONTROL_PLANE_AMI_ID=ami-xxyyzz
+export AWS_CONTROL_PLANE_ADDL_SEC_GROUPS='[{id: sg-xxyyzz}]'
+export AWS_CONTROL_PLANE_IAM_PROFILE=CAPI_AWS_ControlPlane
 
 ## Worker vars
-export WORKER_POOL_MIN=1
-export WORKER_POOL_DESIRED=3
-export WORKER_POOL_MAX=10
-export WORKER_INSTANCE_TYPE=t3.large
-export WORKER_VOL_SIZE=50
-export WORKER_AMI_ID=ami-xxyyzz
-export WORKER_ADDL_SEC_GROUPS='[{id: sg-xxyyzz}]'
-export WORKER_IAM_PROFILE=CAPI_AWS_Worker
+export AWS_WORKER_POOL_MIN=1
+export AWS_WORKER_POOL_DESIRED=3
+export AWS_WORKER_POOL_MAX=10
+export AWS_NODE_MACHINE_TYPE=t3.large
+export AWS_NODE_VOL_SIZE=50
+export AWS_NODE_AMI_ID=ami-xxyyzz
+export AWS_NODE_ADDL_SEC_GROUPS='[{id: sg-xxyyzz}]'
+export AWS_NODE_IAM_PROFILE=CAPI_AWS_Worker

--- a/aws/autoscaling-workers/autoscaling-workers.yaml
+++ b/aws/autoscaling-workers/autoscaling-workers.yaml
@@ -23,13 +23,13 @@ kind: AWSCluster
 metadata:
   name: ${CLUSTER_NAME}
 spec:
-  region: ${REGION}
-  sshKeyName: ${SSH_KEY}
+  region: ${AWS_REGION}
+  sshKeyName: ${AWS_SSH_KEY_NAME}
   networkSpec:
     vpc:
-      id: ${VPC_ID}
+      id: ${AWS_VPC_ID}
     subnets:
-      - id: ${SUBNET}
+      - id: ${AWS_SUBNET}
 ---
 ## Control plane configs
 
@@ -42,25 +42,25 @@ spec:
     spec:
       cloudInit:
         insecureSkipSecretsManager: true
-      instanceType: ${CP_INSTANCE_TYPE}
+      instanceType: ${AWS_CONTROL_PLANE_MACHINE_TYPE}
       rootVolume:
-        size: ${CP_VOL_SIZE}
-      sshKeyName: ${SSH_KEY}
+        size: ${AWS_CONTROL_PLANE_VOL_SIZE}
+      sshKeyName: ${AWS_SSH_KEY_NAME}
       ami:
-        id: ${CP_AMI_ID}
-      additionalSecurityGroups: ${CP_ADDL_SEC_GROUPS}
+        id: ${AWS_CONTROL_PLANE_AMI_ID}
+      additionalSecurityGroups: ${AWS_CONTROL_PLANE_ADDL_SEC_GROUPS}
       publicIP: true
-      iamInstanceProfile: ${CP_IAM_PROFILE}
+      iamInstanceProfile: ${AWS_CONTROL_PLANE_IAM_PROFILE}
       subnet:
-        id: ${SUBNET}
+        id: ${AWS_SUBNET}
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
 kind: TalosControlPlane
 metadata:
   name: ${CLUSTER_NAME}-controlplane
 spec:
-  version: v${K8S_VERSION}
-  replicas: ${CP_COUNT}
+  version: v${KUBERNETES_VERSION}
+  replicas: ${CONTROL_PLANE_MACHINE_COUNT}
   infrastructureTemplate:
     kind: AWSMachineTemplate
     apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
@@ -84,8 +84,8 @@ spec:
           value:
             enabled: true
             manifests:
-              - https://raw.githubusercontent.com/kubernetes/cloud-provider-aws/${CLOUD_PROVIDER_VERSION}/manifests/rbac.yaml
-              - https://raw.githubusercontent.com/kubernetes/cloud-provider-aws/${CLOUD_PROVIDER_VERSION}/manifests/aws-cloud-controller-manager-daemonset.yaml
+              - https://raw.githubusercontent.com/kubernetes/cloud-provider-aws/${AWS_CLOUD_PROVIDER_VERSION}/manifests/rbac.yaml
+              - https://raw.githubusercontent.com/kubernetes/cloud-provider-aws/${AWS_CLOUD_PROVIDER_VERSION}/manifests/aws-cloud-controller-manager-daemonset.yaml
     controlplane:
       generateType: controlplane
       talosVersion: ${TALOS_VERSION}
@@ -113,7 +113,6 @@ apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
 kind: TalosConfig
 metadata:
   name: ${CLUSTER_NAME}-workers
-  namespace: default
 spec:
   generateType: join
   talosVersion: ${TALOS_VERSION}
@@ -132,7 +131,7 @@ metadata:
   name: ${CLUSTER_NAME}-workers
 spec:
   clusterName: ${CLUSTER_NAME}
-  replicas: ${WORKER_POOL_DESIRED}
+  replicas: ${AWS_WORKER_POOL_DESIRED}
   template:
     spec:
       bootstrap:
@@ -145,22 +144,22 @@ spec:
         apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
         kind: AWSMachinePool
         name: ${CLUSTER_NAME}-workers
-      version: ${K8S_VERSION}
+      version: ${KUBERNETES_VERSION}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: AWSMachinePool
 metadata:
   name: ${CLUSTER_NAME}-workers
 spec:
-  minSize: ${WORKER_POOL_MIN}
-  maxSize: ${WORKER_POOL_MAX}
+  minSize: ${AWS_WORKER_POOL_MIN}
+  maxSize: ${AWS_WORKER_POOL_MAX}
   awsLaunchTemplate:
-    instanceType: ${WORKER_INSTANCE_TYPE}
-    sshKeyName: ${SSH_KEY}
-    additionalSecurityGroups: ${WORKER_ADDL_SEC_GROUPS}
+    instanceType: ${AWS_NODE_MACHINE_TYPE}
+    sshKeyName: ${AWS_SSH_KEY_NAME}
+    additionalSecurityGroups: ${AWS_NODE_ADDL_SEC_GROUPS}
     rootVolume:
-      size: ${WORKER_VOL_SIZE}
+      size: ${AWS_NODE_VOL_SIZE}
     ami:
-      id: ${WORKER_AMI_ID}
-    iamInstanceProfile: ${WORKER_IAM_PROFILE}
+      id: ${AWS_NODE_AMI_ID}
+    iamInstanceProfile: ${AWS_NODE_IAM_PROFILE}
 ---

--- a/aws/multi-az/multi-az.env
+++ b/aws/multi-az/multi-az.env
@@ -1,36 +1,36 @@
 ## Cluster-wide vars
 
 ### Subnets
-export PUB_SUB_A='{id: subnet-xxyyzz}'
-export PUB_SUB_B='{id: subnet-xxyyzz}'
-export PUB_SUB_C='{id: subnet-xxyyzz}'
-export PRIV_SUBS='{id: subnet-xxyyzz},{id: subnet-xxyyzz},{id: subnet-xxyyzz}'
-export SUBNETS="[$PUB_SUB_A,$PUB_SUB_B,$PUB_SUB_C,$PRIV_SUBS]"
+export AWS_PUB_SUB_A='{id: subnet-xxyyzz}'
+export AWS_PUB_SUB_B='{id: subnet-xxyyzz}'
+export AWS_PUB_SUB_C='{id: subnet-xxyyzz}'
+export AWS_PRIV_SUBS='{id: subnet-xxyyzz},{id: subnet-xxyyzz},{id: subnet-xxyyzz}'
+export AWS_SUBNETS="[$PUB_SUB_A,$PUB_SUB_B,$PUB_SUB_C,$PRIV_SUBS]"
 
 ### Everything Else
 export CLUSTER_NAME=talos-aws-test
-export REGION=us-east-1
-export SSH_KEY=talos-ssh
-export VPC_ID=vpc-xxyyyzz
-export SUBNET=subnet-xxyyzz
+export AWS_REGION=us-east-1
+export AWS_SSH_KEY_NAME=talos-ssh
+export AWS_VPC_ID=vpc-xxyyyzz
 export CALICO_VERSION=v3.18
-export K8S_VERSION=1.21.0
+export KUBERNETES_VERSION=1.21.0
 export TALOS_VERSION=v0.10
-export CLOUD_PROVIDER_VERSION=v1.20.0-alpha.0
+export AWS_CLOUD_PROVIDER_VERSION=v1.20.0-alpha.0
 
 ## Control plane vars
-export CP_LB_URL=xxyyzz.elb.us-east-1.amazonaws.com
-export CP_COUNT=3
-export CP_INSTANCE_TYPE=t3.large
-export CP_VOL_SIZE=50
-export CP_AMI_ID=ami-xxyyzz
-export CP_ADDL_SEC_GROUPS='[{id: sg-xxyyzz}]'
-export CP_IAM_PROFILE=CAPI_AWS_ControlPlane
+export AWS_CONTROL_PLANE_LB_URL=xxyyzz.elb.us-east-1.amazonaws.com
+export CONTROL_PLANE_MACHINE_COUNT=3
+export AWS_CONTROL_PLANE_MACHINE_TYPE=t3.large
+export AWS_CONTROL_PLANE_VOL_SIZE=50
+export AWS_CONTROL_PLANE_AMI_ID=ami-xxyyzz
+export AWS_CONTROL_PLANE_ADDL_SEC_GROUPS='[{id: sg-xxyyzz}]'
+export AWS_CONTROL_PLANE_IAM_PROFILE=CAPI_AWS_ControlPlane
 
 ## Worker vars
-export WORKER_COUNT_PER_AZ=1
-export WORKER_INSTANCE_TYPE=t3.large
-export WORKER_VOL_SIZE=50
-export WORKER_AMI_ID=ami-xxyyzz
-export WORKER_ADDL_SEC_GROUPS='[{id: sg-xxyyzz}]'
-export WORKER_IAM_PROFILE=CAPI_AWS_Worker
+### Note that machine count is per-AZ
+export WORKER_MACHINE_COUNT=1
+export AWS_NODE_MACHINE_TYPE=t3.large
+export AWS_NODE_VOL_SIZE=50
+export AWS_NODE_AMI_ID=ami-xxyyzz
+export AWS_NODE_ADDL_SEC_GROUPS='[{id: sg-xxyyzz}]'
+export AWS_NODE_IAM_PROFILE=CAPI_AWS_Worker

--- a/aws/multi-az/multi-az.yaml
+++ b/aws/multi-az/multi-az.yaml
@@ -23,12 +23,12 @@ kind: AWSCluster
 metadata:
   name: ${CLUSTER_NAME}
 spec:
-  region: ${REGION}
-  sshKeyName: ${SSH_KEY}
+  region: ${AWS_REGION}
+  sshKeyName: ${AWS_SSH_KEY_NAME}
   networkSpec:
     vpc:
-      id: ${VPC_ID}
-    subnets: ${SUBNETS}
+      id: ${AWS_VPC_ID}
+    subnets: ${AWS_SUBNETS}
 ---
 ## Control plane configs
 
@@ -41,22 +41,22 @@ spec:
     spec:
       cloudInit:
         insecureSkipSecretsManager: true
-      instanceType: ${CP_INSTANCE_TYPE}
+      instanceType: ${AWS_CONTROL_PLANE_MACHINE_TYPE}
       rootVolume:
-        size: ${CP_VOL_SIZE}
+        size: ${AWS_CONTROL_PLANE_VOL_SIZE}
       sshKeyName: ${SSH_KEY}
       ami:
-        id: ${CP_AMI_ID}
-      additionalSecurityGroups: ${CP_ADDL_SEC_GROUPS}
-      iamInstanceProfile: ${CP_IAM_PROFILE}
+        id: ${AWS_CONTROL_PLANE_AMI_ID}
+      additionalSecurityGroups: ${AWS_CONTROL_PLANE_ADDL_SEC_GROUPS}
+      iamInstanceProfile: ${AWS_CONTROL_PLANE_IAM_PROFILE}
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
 kind: TalosControlPlane
 metadata:
   name: ${CLUSTER_NAME}-controlplane
 spec:
-  version: v${K8S_VERSION}
-  replicas: ${CP_COUNT}
+  version: v${KUBERNETES_VERSION}
+  replicas: ${CONTROL_PLANE_MACHINE_COUNT}
   infrastructureTemplate:
     kind: AWSMachineTemplate
     apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
@@ -85,7 +85,7 @@ spec:
         - op: add
           path: /machine/certSANs
           value:
-            - ${CP_LB_URL}
+            - ${AWS_CONTROL_PLANE_LB_URL}
     controlplane:
       generateType: controlplane
       talosVersion: ${TALOS_VERSION}
@@ -104,12 +104,12 @@ spec:
           value:
             enabled: true
             manifests:
-              - https://raw.githubusercontent.com/kubernetes/cloud-provider-aws/${CLOUD_PROVIDER_VERSION}/manifests/rbac.yaml
-              - https://raw.githubusercontent.com/kubernetes/cloud-provider-aws/${CLOUD_PROVIDER_VERSION}/manifests/aws-cloud-controller-manager-daemonset.yaml
+              - https://raw.githubusercontent.com/kubernetes/cloud-provider-aws/${AWS_CLOUD_PROVIDER_VERSION}/manifests/rbac.yaml
+              - https://raw.githubusercontent.com/kubernetes/cloud-provider-aws/${AWS_CLOUD_PROVIDER_VERSION}/manifests/aws-cloud-controller-manager-daemonset.yaml
         - op: add
           path: /machine/certSANs
           value:
-            - ${CP_LB_URL}
+            - ${AWS_CONTROL_PLANE_LB_URL}
 ---
 ## Worker deployment configs
 
@@ -142,7 +142,7 @@ metadata:
   name: ${CLUSTER_NAME}-workers-a
 spec:
   clusterName: ${CLUSTER_NAME}
-  replicas: ${WORKER_COUNT_PER_AZ}
+  replicas: ${WORKER_MACHINE_COUNT}
   selector:
     matchLabels:
       cluster.x-k8s.io/cluster-name: ${CLUSTER_NAME}
@@ -163,7 +163,7 @@ spec:
         apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
         kind: AWSMachineTemplate
         name: ${CLUSTER_NAME}-workers-a
-      version: ${K8S_VERSION}
+      version: ${KUBERNETES_VERSION}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: AWSMachineTemplate
@@ -174,16 +174,16 @@ spec:
     spec:
       cloudInit:
         insecureSkipSecretsManager: true
-      instanceType: ${WORKER_INSTANCE_TYPE}
+      instanceType: ${AWS_NODE_MACHINE_TYPE}
       rootVolume:
-        size: ${WORKER_VOL_SIZE}
-      sshKeyName: ${SSH_KEY}
+        size: ${AWS_NODE_VOL_SIZE}
+      sshKeyName: ${AWS_SSH_KEY_NAME}
       ami:
-        id: ${WORKER_AMI_ID}
-      subnet: ${PUB_SUB_A}
+        id: ${AWS_NODE_AMI_ID}
+      subnet: ${AWS_PUB_SUB_A}
       publicIP: true
-      iamInstanceProfile: ${WORKER_IAM_PROFILE}
-      additionalSecurityGroups: ${WORKER_ADDL_SEC_GROUPS}
+      iamInstanceProfile: ${AWS_NODE_IAM_PROFILE}
+      additionalSecurityGroups: ${AWS_NODE_ADDL_SEC_GROUPS}
 ---
 ### Worker group B
 apiVersion: cluster.x-k8s.io/v1alpha3
@@ -195,7 +195,7 @@ metadata:
   name: ${CLUSTER_NAME}-workers-b
 spec:
   clusterName: ${CLUSTER_NAME}
-  replicas: ${WORKER_COUNT_PER_AZ}
+  replicas: ${WORKER_MACHINE_COUNT}
   selector:
     matchLabels:
       cluster.x-k8s.io/cluster-name: ${CLUSTER_NAME}
@@ -216,7 +216,7 @@ spec:
         apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
         kind: AWSMachineTemplate
         name: ${CLUSTER_NAME}-workers-b
-      version: ${K8S_VERSION}
+      version: ${KUBERNETES_VERSION}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: AWSMachineTemplate
@@ -227,16 +227,16 @@ spec:
     spec:
       cloudInit:
         insecureSkipSecretsManager: true
-      instanceType: ${WORKER_INSTANCE_TYPE}
+      instanceType: ${AWS_NODE_MACHINE_TYPE}
       rootVolume:
-        size: ${WORKER_VOL_SIZE}
-      sshKeyName: ${SSH_KEY}
+        size: ${AWS_NODE_VOL_SIZE}
+      sshKeyName: ${AWS_SSH_KEY_NAME}
       ami:
-        id: ${WORKER_AMI_ID}
-      subnet: ${PUB_SUB_B}
+        id: ${AWS_NODE_AMI_ID}
+      subnet: ${AWS_PUB_SUB_B}
       publicIP: true
-      iamInstanceProfile: ${WORKER_IAM_PROFILE}
-      additionalSecurityGroups: ${WORKER_ADDL_SEC_GROUPS}
+      iamInstanceProfile: ${AWS_NODE_IAM_PROFILE}
+      additionalSecurityGroups: ${AWS_NODE_ADDL_SEC_GROUPS}
 ---
 ### Worker group C
 apiVersion: cluster.x-k8s.io/v1alpha3
@@ -248,7 +248,7 @@ metadata:
   name: ${CLUSTER_NAME}-workers-c
 spec:
   clusterName: ${CLUSTER_NAME}
-  replicas: ${WORKER_COUNT_PER_AZ}
+  replicas: ${WORKER_MACHINE_COUNT}
   selector:
     matchLabels:
       cluster.x-k8s.io/cluster-name: ${CLUSTER_NAME}
@@ -269,7 +269,7 @@ spec:
         apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
         kind: AWSMachineTemplate
         name: ${CLUSTER_NAME}-workers-c
-      version: ${K8S_VERSION}
+      version: ${KUBERNETES_VERSION}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: AWSMachineTemplate
@@ -280,17 +280,16 @@ spec:
     spec:
       cloudInit:
         insecureSkipSecretsManager: true
-      instanceType: ${WORKER_INSTANCE_TYPE}
+      instanceType: ${AWS_NODE_MACHINE_TYPE}
       rootVolume:
-        size: ${WORKER_VOL_SIZE}
-      sshKeyName: ${SSH_KEY}
+        size: ${AWS_NODE_VOL_SIZE}
+      sshKeyName: ${AWS_SSH_KEY_NAME}
       ami:
-        id: ${WORKER_AMI_ID}
-      subnet: ${PUB_SUB_C}
+        id: ${AWS_NODE_AMI_ID}
+      subnet: ${AWS_PUB_SUB_C}
       publicIP: true
-      iamInstanceProfile: ${WORKER_IAM_PROFILE}
-      additionalSecurityGroups: ${WORKER_ADDL_SEC_GROUPS}
-
+      iamInstanceProfile: ${AWS_NODE_IAM_PROFILE}
+      additionalSecurityGroups: ${AWS_NODE_ADDL_SEC_GROUPS}
 ---
 ## Health check for all workers
 apiVersion: cluster.x-k8s.io/v1alpha3

--- a/aws/standard/standard.env
+++ b/aws/standard/standard.env
@@ -1,26 +1,26 @@
 ## Cluster-wide vars
 export CLUSTER_NAME=talos-aws-test
-export REGION=us-east-1
-export SSH_KEY=talos-ssh
-export VPC_ID=vpc-xxyyyzz
-export SUBNET=subnet-xxyyzz
+export AWS_REGION=us-east-1
+export AWS_SSH_KEY_NAME=talos-ssh
+export AWS_VPC_ID=vpc-xxyyyzz
+export AWS_SUBNET=subnet-xxyyzz
 export CALICO_VERSION=v3.18
-export K8S_VERSION=1.21.0
+export KUBERNETES_VERSION=1.21.0
 export TALOS_VERSION=v0.10
-export CLOUD_PROVIDER_VERSION=v1.20.0-alpha.0
+export AWS_CLOUD_PROVIDER_VERSION=v1.20.0-alpha.0
 
 ## Control plane vars
-export CP_COUNT=3
-export CP_INSTANCE_TYPE=t3.large
-export CP_VOL_SIZE=50
-export CP_AMI_ID=ami-xxyyzz
-export CP_ADDL_SEC_GROUPS='[{id: sg-xxyyzz}]'
-export CP_IAM_PROFILE=CAPI_AWS_ControlPlane
+export CONTROL_PLANE_MACHINE_COUNT=3
+export AWS_CONTROL_PLANE_MACHINE_TYPE=t3.large
+export AWS_CONTROL_PLANE_VOL_SIZE=50
+export AWS_CONTROL_PLANE_AMI_ID=ami-xxyyzz
+export AWS_CONTROL_PLANE_ADDL_SEC_GROUPS='[{id: sg-xxyyzz}]'
+export AWS_CONTROL_PLANE_IAM_PROFILE=CAPI_AWS_ControlPlane
 
 ## Worker vars
-export WORKER_COUNT=3
-export WORKER_INSTANCE_TYPE=t3.large
-export WORKER_VOL_SIZE=50
-export WORKER_AMI_ID=ami-xxyyzz
-export WORKER_ADDL_SEC_GROUPS='[{id: sg-xxyyzz}]'
-export WORKER_IAM_PROFILE=CAPI_AWS_Worker
+export WORKER_MACHINE_COUNT=3
+export AWS_NODE_MACHINE_TYPE=t3.large
+export AWS_NODE_VOL_SIZE=50
+export AWS_NODE_AMI_ID=ami-xxyyzz
+export AWS_NODE_ADDL_SEC_GROUPS='[{id: sg-xxyyzz}]'
+export AWS_NODE_IAM_PROFILE=CAPI_AWS_Worker

--- a/aws/standard/standard.yaml
+++ b/aws/standard/standard.yaml
@@ -1,5 +1,4 @@
 ## Cluster configs
-
 apiVersion: cluster.x-k8s.io/v1alpha3
 kind: Cluster
 metadata:
@@ -23,16 +22,15 @@ kind: AWSCluster
 metadata:
   name: ${CLUSTER_NAME}
 spec:
-  region: ${REGION}
-  sshKeyName: ${SSH_KEY}
+  region: ${AWS_REGION}
+  sshKeyName: ${AWS_SSH_KEY_NAME}
   networkSpec:
     vpc:
-      id: ${VPC_ID}
+      id: ${AWS_VPC_ID}
     subnets:
-      - id: ${SUBNET}
+      - id: ${AWS_SUBNET}
 ---
 ## Control plane configs
-
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: AWSMachineTemplate
 metadata:
@@ -42,25 +40,25 @@ spec:
     spec:
       cloudInit:
         insecureSkipSecretsManager: true
-      instanceType: ${CP_INSTANCE_TYPE}
+      instanceType: ${AWS_CONTROL_PLANE_MACHINE_TYPE}
       rootVolume:
-        size: ${CP_VOL_SIZE}
-      sshKeyName: ${SSH_KEY}
+        size: ${AWS_CONTROL_PLANE_VOL_SIZE}
+      sshKeyName: ${AWS_SSH_KEY_NAME}
       ami:
-        id: ${CP_AMI_ID}
-      additionalSecurityGroups: ${CP_ADDL_SEC_GROUPS}
+        id: ${AWS_CONTROL_PLANE_AMI_ID}
+      additionalSecurityGroups: ${AWS_CONTROL_PLANE_ADDL_SEC_GROUPS}
       publicIP: true
-      iamInstanceProfile: ${CP_IAM_PROFILE}
+      iamInstanceProfile: ${AWS_CONTROL_PLANE_IAM_PROFILE}
       subnet:
-        id: ${SUBNET}
+        id: ${AWS_SUBNET}
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
 kind: TalosControlPlane
 metadata:
   name: ${CLUSTER_NAME}-controlplane
 spec:
-  version: v${K8S_VERSION}
-  replicas: ${CP_COUNT}
+  version: v${KUBERNETES_VERSION}
+  replicas: ${CONTROL_PLANE_MACHINE_COUNT}
   infrastructureTemplate:
     kind: AWSMachineTemplate
     apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
@@ -84,8 +82,8 @@ spec:
           value:
             enabled: true
             manifests:
-              - https://raw.githubusercontent.com/kubernetes/cloud-provider-aws/${CLOUD_PROVIDER_VERSION}/manifests/rbac.yaml
-              - https://raw.githubusercontent.com/kubernetes/cloud-provider-aws/${CLOUD_PROVIDER_VERSION}/manifests/aws-cloud-controller-manager-daemonset.yaml
+              - https://raw.githubusercontent.com/kubernetes/cloud-provider-aws/${AWS_CLOUD_PROVIDER_VERSION}/manifests/rbac.yaml
+              - https://raw.githubusercontent.com/kubernetes/cloud-provider-aws/${AWS_CLOUD_PROVIDER_VERSION}/manifests/aws-cloud-controller-manager-daemonset.yaml
     controlplane:
       generateType: controlplane
       talosVersion: ${TALOS_VERSION}
@@ -104,11 +102,10 @@ spec:
           value:
             enabled: true
             manifests:
-              - https://raw.githubusercontent.com/kubernetes/cloud-provider-aws/${CLOUD_PROVIDER_VERSION}/manifests/rbac.yaml
-              - https://raw.githubusercontent.com/kubernetes/cloud-provider-aws/${CLOUD_PROVIDER_VERSION}/manifests/aws-cloud-controller-manager-daemonset.yaml
+              - https://raw.githubusercontent.com/kubernetes/cloud-provider-aws/${AWS_CLOUD_PROVIDER_VERSION}/manifests/rbac.yaml
+              - https://raw.githubusercontent.com/kubernetes/cloud-provider-aws/${AWS_CLOUD_PROVIDER_VERSION}/manifests/aws-cloud-controller-manager-daemonset.yaml
 ---
 ## Worker deployment configs
-
 apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
 kind: TalosConfigTemplate
 metadata:
@@ -136,7 +133,7 @@ metadata:
   name: ${CLUSTER_NAME}-workers
 spec:
   clusterName: ${CLUSTER_NAME}
-  replicas: ${WORKER_COUNT}
+  replicas: ${WORKER_MACHINE_COUNT}
   selector:
     matchLabels:
       cluster.x-k8s.io/cluster-name: ${CLUSTER_NAME}
@@ -157,7 +154,7 @@ spec:
         apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
         kind: AWSMachineTemplate
         name: ${CLUSTER_NAME}-workers
-      version: ${K8S_VERSION}
+      version: ${KUBERNETES_VERSION}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: AWSMachineTemplate
@@ -168,20 +165,19 @@ spec:
     spec:
       cloudInit:
         insecureSkipSecretsManager: true
-      instanceType: ${WORKER_INSTANCE_TYPE}
+      instanceType: ${AWS_NODE_MACHINE_TYPE}
       rootVolume:
-        size: ${WORKER_VOL_SIZE}
-      sshKeyName: ${SSH_KEY}
+        size: ${AWS_NODE_VOL_SIZE}
+      sshKeyName: ${AWS_SSH_KEY_NAME}
       ami:
-        id: ${WORKER_AMI_ID}
+        id: ${AWS_NODE_AMI_ID}
       subnet:
-        id: ${SUBNET}
-      additionalSecurityGroups: ${WORKER_ADDL_SEC_GROUPS}
+        id: ${AWS_SUBNET}
+      additionalSecurityGroups: ${AWS_NODE_ADDL_SEC_GROUPS}
       publicIP: true
-      iamInstanceProfile: ${WORKER_IAM_PROFILE}
+      iamInstanceProfile: ${AWS_NODE_IAM_PROFILE}
 ---
 ## Health check for workers
-
 apiVersion: cluster.x-k8s.io/v1alpha3
 kind: MachineHealthCheck
 metadata:


### PR DESCRIPTION
This PR updates the templates to use variables that are built in to
clusterctl for various things like Kubernetes version. Also renames
others to be clear that they are for AWS cluster manifests.

Signed-off-by: Spencer Smith <spencer.smith@talos-systems.com>
