### PR TITLE
chore: use templated ccm manifests temporarily

### DIFF
--- a/aws/manifests/ccm.yaml
+++ b/aws/manifests/ccm.yaml
@@ -1,0 +1,190 @@
+---
+# Source: aws-cloud-controller-manager/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cloud-controller-manager
+  namespace: kube-system
+  labels:
+    helm.sh/chart: "aws-cloud-controller-manager-0.0.6"
+---
+# Source: aws-cloud-controller-manager/templates/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system:cloud-controller-manager
+  labels:
+    helm.sh/chart: "aws-cloud-controller-manager-0.0.6"
+rules:
+  - apiGroups:
+    - ""
+    resources:
+    - events
+    verbs:
+    - create
+    - patch
+    - update
+  - apiGroups:
+    - ""
+    resources:
+    - nodes
+    verbs:
+    - '*'
+  - apiGroups:
+    - ""
+    resources:
+    - nodes/status
+    verbs:
+    - patch
+  - apiGroups:
+    - ""
+    resources:
+    - services
+    verbs:
+    - list
+    - patch
+    - update
+    - watch
+  - apiGroups:
+    - ""
+    resources:
+    - services/status
+    verbs:
+    - list
+    - patch
+    - update
+    - watch
+  - apiGroups:
+    - ""
+    resources:
+    - serviceaccounts
+    verbs:
+    - create
+  - apiGroups:
+    - ""
+    resources:
+    - persistentvolumes
+    verbs:
+    - get
+    - list
+    - update
+    - watch
+  - apiGroups:
+    - ""
+    resources:
+    - endpoints
+    verbs:
+    - create
+    - get
+    - list
+    - watch
+    - update
+  - apiGroups:
+    - coordination.k8s.io
+    resources:
+    - leases
+    verbs:
+    - create
+    - get
+    - list
+    - watch
+    - update
+  - apiGroups:
+    - ""
+    resources:
+    - serviceaccounts/token
+    verbs:
+    - create
+---
+# Source: aws-cloud-controller-manager/templates/cluserrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system:cloud-controller-manager
+  labels:
+    helm.sh/chart: "aws-cloud-controller-manager-0.0.6"
+roleRef:
+  kind: ClusterRole
+  name: system:cloud-controller-manager
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- apiGroup: ""
+  kind: ServiceAccount
+  name: cloud-controller-manager
+  namespace: kube-system
+---
+# Source: aws-cloud-controller-manager/templates/rolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cloud-controller-manager:apiserver-authentication-reader
+  namespace: kube-system
+  labels:
+    helm.sh/chart: "aws-cloud-controller-manager-0.0.6"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
+subjects:
+- apiGroup: ""
+  kind: ServiceAccount
+  name: cloud-controller-manager
+  namespace: kube-system
+---
+# Source: aws-cloud-controller-manager/templates/daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: aws-cloud-controller-manager
+  labels:
+    k8s-app:  aws-cloud-controller-manager
+    helm.sh/chart: "aws-cloud-controller-manager-0.0.6"
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      k8s-app:  aws-cloud-controller-manager
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      name: aws-cloud-controller-manager
+      labels:
+        k8s-app:  aws-cloud-controller-manager
+    spec:
+      tolerations:
+        - effect: NoSchedule
+          key: node.cloudprovider.kubernetes.io/uninitialized
+          value: "true"
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/control-plane
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                - key: node-role.kubernetes.io/master
+                  operator: Exists
+              - matchExpressions:
+                - key: node-role.kubernetes.io/control-plane
+                  operator: Exists
+      priorityClassName: system-node-critical
+      serviceAccountName: cloud-controller-manager
+      securityContext:
+        {}
+      containers:
+        - name: aws-cloud-controller-manager
+          image: "registry.k8s.io/provider-aws/cloud-controller-manager:v1.24.1"
+          args:
+            - --v=2
+            - --cloud-provider=aws
+            - --configure-cloud-routes=false
+          resources:
+            requests:
+              cpu: 200m
+          env:
+            []
+          securityContext:
+            {}

--- a/aws/standard/standard.yaml
+++ b/aws/standard/standard.yaml
@@ -76,7 +76,9 @@ spec:
           value:
             name: custom
             urls:
-              - https://docs.projectcalico.org/${CALICO_VERSION}/manifests/calico.yaml
+              # TODO: noel: revert to `${CALICO_VERSION}` once we have a calico release with
+              # fixed from https://github.com/projectcalico/calico/pull/6370
+              - https://docs.projectcalico.org/master/manifests/calico.yaml
         - op: add
           path: /machine/kubelet/registerWithFQDN
           value: true
@@ -85,8 +87,9 @@ spec:
           value:
             enabled: true
             manifests:
-              - https://raw.githubusercontent.com/kubernetes/cloud-provider-aws/${AWS_CLOUD_PROVIDER_VERSION}/manifests/rbac.yaml
-              - https://raw.githubusercontent.com/kubernetes/cloud-provider-aws/${AWS_CLOUD_PROVIDER_VERSION}/manifests/aws-cloud-controller-manager-daemonset.yaml
+              # TODO: noel: rever to `${AWS_CLOUD_PROVIDER_VERSION}` once we have a aws-cloud-provider release with
+              # fixes from https://github.com/kubernetes/cloud-provider-aws/pull/431
+              - https://raw.githubusercontent.com/siderolabs/cluster-api-templates/main/aws/manifests/ccm.yaml
 ---
 ## Worker deployment configs
 apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3


### PR DESCRIPTION
Use the templated CCM manifets until
https://github.com/kubernetes/cloud-provider-aws/pull/431 is merged.

Signed-off-by: Noel Georgi <git@frezbo.dev>