### PR TITLE
feat: update aws ccm image to v1.25.1

### DIFF
--- a/aws/manifests/ccm.yaml
+++ b/aws/manifests/ccm.yaml
@@ -169,7 +169,7 @@ spec:
         {}
       containers:
         - name: aws-cloud-controller-manager
-          image: "registry.k8s.io/provider-aws/cloud-controller-manager:v1.23.0-alpha.0"
+          image: "registry.k8s.io/provider-aws/cloud-controller-manager:v1.25.1"
           args:
             - --v=2
             - --cloud-provider=aws


### PR DESCRIPTION
Manually update the aws ccm image to v1.25.1

Closes: #23

Signed-off-by: Noel Georgi <git@frezbo.dev>